### PR TITLE
feat(host): allow for a configurable host

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To get a client instance use the `ClientFactory`  Class.
 
 ```c#
     ClientConfig config = new ClientConfig.Builder() {
-        Environment = Environments.Sandbox,
+        Hostname = Environments.Sandbox,
         ConsumerKey = "theConsumerKey",
         ConsumerSecret = "theConsumerSecret",
         // To enable exponential backoff retries
@@ -77,7 +77,7 @@ You can also get a client instance if you have an access token. This method is n
 ```c#
     // Use a token instead of a client/secret pair
     ClientConfig config = new ClientConfig.Builder() {
-        Environment = Environments.Sandbox,
+        Hostname = Environments.Sandbox,
         Token = "my_token"
     };
     var client = ClientFactory.Create(config);

--- a/smartobjects-net-client-ittest/ITTestHelper.cs
+++ b/smartobjects-net-client-ittest/ITTestHelper.cs
@@ -21,7 +21,7 @@ namespace Mnubo.SmartObjects.Client.ITTest
             return ClientFactory.Create(
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     ConsumerKey = Environment.GetEnvironmentVariable("CONSUMER_KEY"),
                     ConsumerSecret = Environment.GetEnvironmentVariable("CONSUMER_SECRET")
                 }

--- a/smartobjects-net-client-test/Config/ClientConfigTest.cs
+++ b/smartobjects-net-client-test/Config/ClientConfigTest.cs
@@ -12,12 +12,12 @@ namespace Mnubo.SmartObjects.Client.Test.Config
         {
             ClientConfig config = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "CK",
                 ConsumerSecret = "CS"
             };
 
-            Assert.AreEqual(config.Environment, ClientConfig.Environments.Sandbox);
+            Assert.AreEqual(config.Hostname, ClientConfig.Environments.Sandbox);
             Assert.AreEqual(config.ConsumerKey, "CK");
             Assert.AreEqual(config.ConsumerSecret, "CS");
             Assert.AreEqual(config.ClientTimeout, ClientConfig.Builder.DefaultTimeout);
@@ -30,7 +30,7 @@ namespace Mnubo.SmartObjects.Client.Test.Config
         {
             ClientConfig config = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "CK",
                 ConsumerSecret = "CS",
                 ClientTimeout = 50000,
@@ -38,7 +38,7 @@ namespace Mnubo.SmartObjects.Client.Test.Config
                 CompressionEnabled = false
             };
 
-            Assert.AreEqual(config.Environment, ClientConfig.Environments.Sandbox);
+            Assert.AreEqual(config.Hostname, ClientConfig.Environments.Sandbox);
             Assert.AreEqual(config.ConsumerKey, "CK");
             Assert.AreEqual(config.ConsumerSecret, "CS");
             Assert.AreEqual(config.ClientTimeout, 50000);
@@ -52,7 +52,7 @@ namespace Mnubo.SmartObjects.Client.Test.Config
         {
             ClientConfig config = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "CK",
                 ConsumerSecret = "CS",
                 ClientTimeout = 155,
@@ -60,7 +60,7 @@ namespace Mnubo.SmartObjects.Client.Test.Config
                 CompressionEnabled = true
             };
 
-            Assert.AreEqual(config.Environment, ClientConfig.Environments.Sandbox);
+            Assert.AreEqual(config.Hostname, ClientConfig.Environments.Sandbox);
             Assert.AreEqual(config.ConsumerKey, "CK");
             Assert.AreEqual(config.ConsumerSecret, "CS");
             Assert.AreEqual(config.ClientTimeout, 155);
@@ -75,7 +75,7 @@ namespace Mnubo.SmartObjects.Client.Test.Config
         [TestCase(ClientConfig.Environments.Sandbox, "CK", "CS", -9, 555, "clientTimeout must be a positive number.")]
         [TestCase(ClientConfig.Environments.Sandbox, "CK", "CS", 15, -8, "maxResponseContentBufferSize must be a positive number.")]
         public void ConfigBuilderAdvanceConfigWrongValues(
-            ClientConfig.Environments environment,
+            string environment,
             string securityConsumerKey,
             string securityConsumerSecret,
             int clientTimeout,
@@ -85,7 +85,7 @@ namespace Mnubo.SmartObjects.Client.Test.Config
             ClientConfig config;
             Assert.That(() => config = new ClientConfig.Builder()
             {
-                Environment = environment,
+                Hostname = environment,
                 ConsumerKey = securityConsumerKey,
                 ConsumerSecret = securityConsumerSecret,
                 ClientTimeout = clientTimeout,

--- a/smartobjects-net-client-test/Impl/EventClientTest.cs
+++ b/smartobjects-net-client-test/Impl/EventClientTest.cs
@@ -37,7 +37,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
             config =
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     ConsumerKey = "key",
                     ConsumerSecret = "secret"
                 };          

--- a/smartobjects-net-client-test/Impl/HttpClientTest.cs
+++ b/smartobjects-net-client-test/Impl/HttpClientTest.cs
@@ -33,7 +33,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
             config =
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     ConsumerKey = "key",
                     ConsumerSecret = "secret"
                 };
@@ -60,7 +60,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
             var otherConfig  =
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     Token = "token"
                 };
             var client = new Client.Impl.HttpClient(otherConfig, "http", "localhost", port, SucceedAPIsMockModule.BasePath);
@@ -74,7 +74,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
         {
             var configWithCompression = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "key",
                 ConsumerSecret = "secret",
                 CompressionEnabled = true
@@ -92,7 +92,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
         {
             var configNoCompression = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "key",
                 ConsumerSecret = "secret",
                 CompressionEnabled = false
@@ -111,7 +111,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
         {
             var defaultBackOff = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "key",
                 ConsumerSecret = "secret",
                 ExponentialBackoffConfig = new ExponentialBackoffConfig.On(5, 500, (res, t) => {
@@ -138,7 +138,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
         {
             var defaultBackOff = new ClientConfig.Builder()
             {
-                Environment = ClientConfig.Environments.Sandbox,
+                Hostname = ClientConfig.Environments.Sandbox,
                 ConsumerKey = "key",
                 ConsumerSecret = "secret"
             };

--- a/smartobjects-net-client-test/Impl/OwnerClientTest.cs
+++ b/smartobjects-net-client-test/Impl/OwnerClientTest.cs
@@ -29,7 +29,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
             config =
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     ConsumerKey = "key",
                     ConsumerSecret = "secret"
                 };

--- a/smartobjects-net-client-test/Impl/RestitutionClientTest.cs
+++ b/smartobjects-net-client-test/Impl/RestitutionClientTest.cs
@@ -32,7 +32,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
             config =
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     ConsumerKey = "key",
                     ConsumerSecret = "secret"
                 };

--- a/smartobjects-net-client-test/Impl/SmartObjectClientTest.cs
+++ b/smartobjects-net-client-test/Impl/SmartObjectClientTest.cs
@@ -29,7 +29,7 @@ namespace Mnubo.SmartObjects.Client.Test.Impl
             config =
                 new ClientConfig.Builder()
                 {
-                    Environment = ClientConfig.Environments.Sandbox,
+                    Hostname = ClientConfig.Environments.Sandbox,
                     ConsumerKey = "key",
                     ConsumerSecret = "secret"
                 };

--- a/smartobjects-net-client/Config/ClientConfig.cs
+++ b/smartobjects-net-client/Config/ClientConfig.cs
@@ -12,23 +12,23 @@ namespace Mnubo.SmartObjects.Client.Config
         ///
         /// https://smartobjects.mnubo.com/documentation/api_basics.html
         /// </summary>
-        public enum Environments
+        public static class Environments
         {
             /// <summary>
             /// Using this environment will target the sandbox
             /// </summary>
-            Sandbox,
+            public const string Sandbox = "rest.sandbox.mnubo.com";
 
             /// <summary>
             /// Using this environment will target the production
             /// </summary>
-            Production
+            public const string Production = "rest.api.mnubo.com";
         }
 
         /// <summary>
         /// Gets the Hostname server
         /// </summary>
-        public Environments Environment { get; }
+        public string Hostname { get; }
 
         /// <summary>
         /// get unique identity key provided by mnubo.
@@ -68,10 +68,10 @@ namespace Mnubo.SmartObjects.Client.Config
         private ClientConfig() { }
 
         private ClientConfig(
-            Environments environment,
-            String consumerKey,
-            String consumerSecret,
-            String token,
+            string hostname,
+            string consumerKey,
+            string consumerSecret,
+            string token,
             int clientTimeout,
             long maxResponseContentBufferSize,
             bool compressionEnabled,
@@ -100,7 +100,7 @@ namespace Mnubo.SmartObjects.Client.Config
                 throw new ArgumentException("maxResponseContentBufferSize must be a positive number.");
             }
 
-            Environment = environment;
+            Hostname = hostname;
             ConsumerKey = consumerKey;
             ConsumerSecret = consumerSecret;
             Token = token;
@@ -169,22 +169,22 @@ namespace Mnubo.SmartObjects.Client.Config
             /// <summary>
             /// The Hostname server
             /// </summary>
-            public Environments Environment { get; set; }
+            public string Hostname { get; set; }
 
             /// <summary>
             /// The unique identity key provided by mnubo.
             /// </summary>
-            public String ConsumerKey { get; set; }
+            public string ConsumerKey { get; set; }
 
             /// <summary>
             /// The secret key provided by mnubo.
             /// </summary>
-            public String ConsumerSecret { get; set; }
+            public string ConsumerSecret { get; set; }
 
             /// <summary>
             /// A bearer token fetched from mnubo
             /// </summary>
-            public String Token { get; set; }
+            public string Token { get; set; }
 
             /// <summary>
             /// Timeout in miliseconds to use for requests made by this client instance.
@@ -214,7 +214,7 @@ namespace Mnubo.SmartObjects.Client.Config
             /// Usage:
             /// <code>
             ///  var builder = new ClientConfig.Builder();
-            ///  builder.Environment = ClientConfig.Environments.Sandbox;
+            ///  builder.Hostname = ClientConfig.Environments.Sandbox;
             ///  builder.ConsumerKey = "KEY";
             ///  builder.ConsumerSecret = "SECRET";
             ///  var config = builder.build();
@@ -234,7 +234,7 @@ namespace Mnubo.SmartObjects.Client.Config
             public ClientConfig Build()
             {
                 return new ClientConfig(
-                    Environment,
+                    Hostname,
                     ConsumerKey,
                     ConsumerSecret,
                     Token,

--- a/smartobjects-net-client/Impl/CredentialHandler.cs
+++ b/smartobjects-net-client/Impl/CredentialHandler.cs
@@ -37,7 +37,7 @@ namespace Mnubo.SmartObjects.Client.Impl
 
             UriBuilder uriBuilder = new UriBuilder(
                 HttpClient.DefaultClientSchema,
-                HttpClient.addressMapping[config.Environment], 
+                config.Hostname,
                 HttpClient.DefaultHostPort, 
                 TokenPath);
             uriBuilder.Query = 

--- a/smartobjects-net-client/Impl/HttpClient.cs
+++ b/smartobjects-net-client/Impl/HttpClient.cs
@@ -19,11 +19,6 @@ namespace Mnubo.SmartObjects.Client.Impl
 {
     internal class HttpClient : IDisposable
     {
-        internal static readonly Dictionary<Environments, string> addressMapping = new Dictionary<Environments, string>()
-        {
-            { Environments.Sandbox, "rest.sandbox.mnubo.com" },
-            { Environments.Production, "rest.api.mnubo.com" }
-        };
         internal const string DefaultClientSchema = "https";
         internal const string DefaultScope = "ALL";
         internal const int DefaultHostPort = 443;
@@ -36,7 +31,6 @@ namespace Mnubo.SmartObjects.Client.Impl
         private readonly string basePath;
         private readonly bool compressionEnabled = ClientConfig.Builder.DefaultCompressionEnabled;
         private readonly CredentialHandler credentialHandler;
-        private readonly Environments environment;
         private readonly System.Net.Http.HttpClientHandler handler;
         private readonly System.Net.Http.HttpClient client;
         private readonly RetryPolicy<HttpResponseMessage> policy;
@@ -56,7 +50,7 @@ namespace Mnubo.SmartObjects.Client.Impl
                 }
         }
 
-        internal HttpClient(ClientConfig config) : this(config, DefaultClientSchema, HttpClient.addressMapping[config.Environment], DefaultHostPort, DefaultBasePath) { }
+        internal HttpClient(ClientConfig config) : this(config, DefaultClientSchema, config.Hostname, DefaultHostPort, DefaultBasePath) { }
 
         internal HttpClient(ClientConfig config, string clientSchema, string hostname, int hostPort, string basePath)
         {
@@ -72,7 +66,6 @@ namespace Mnubo.SmartObjects.Client.Impl
                 this.credentialHandler = new StaticTokenCredentialHandler(config.Token);
             }
 
-            this.environment = config.Environment;
             this.compressionEnabled = config.CompressionEnabled;
             this.clientSchema = clientSchema;
             this.hostname = hostname;


### PR DESCRIPTION
replace the environment that uses static url by a string in which
the users can put any host they want.

BREAKING CHANGE:
This change is breaking because it changes Environments enum into a string.
I've kept the constant around to minimize the impact but if users are using
the Environments enum, they'll have to fix their build.

I believe this is a minor change but breaking nonetheless so it will come
with a major version bump.