### PR TITLE
chore(publishing): change publishing to .sh file to respect Travis requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,5 @@ deploy:
   provider: script
   on:
     branch: master
-  script:
-    - dotnet pack smartobjects-net-client/AspenTech.SmartObjects.Client.csproj -p:NuspecFile=../AspenTech.SmartObjects.Client.nuspec -c Release
-    - dotnet nuget push smartobjects-net-client/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+  script: bash scripts/deploy.sh
+    

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,2 @@
+dotnet pack AspenTech.SmartObjects.Client/AspenTech.SmartObjects.Client.csproj -p:NuspecFile=AspenTech.SmartObjects.Client.nuspec -c Release
+dotnet nuget push AspenTech.SmartObjects.Client/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Since previous deploy failed.

Also adjusted paths in the deploy script. They were based on my local test but travis is executing from the root of the repo

See: https://docs.travis-ci.com/user/deployment/script/